### PR TITLE
Add weekly RSS summary feature from Metacurate.io feed

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -17,6 +17,7 @@ EXTENSIONS = [
     "cogs.activity",
     "cogs.admin",
     "cogs.listeners",
+    "cogs.rss",
 ]
 
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -60,6 +60,8 @@ class General(commands.Cog):
             "permissions": "Manage command permissions (Admin)",
             "permissions-view": "View current permissions (Admin)",
             "config": "Change server settings (Admin)",
+            "weeklysummary": "Get this week's RSS news summary",
+            "rss-channel": "Set the channel for weekly summaries (Admin)",
         }
 
         # Always show admin commands to admins

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -1,0 +1,206 @@
+import logging
+
+import aiohttp
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from checks import has_command_permission
+from utils.api import ai_weekly_summary, fetch_rss_feed
+
+log = logging.getLogger(__name__)
+
+
+class RSS(commands.Cog):
+    """Fetches the Metacurate daily RSS feed and posts a weekly AI summary."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.session: aiohttp.ClientSession | None = None
+
+    async def cog_load(self) -> None:
+        self.session = aiohttp.ClientSession()
+        self.daily_fetch.start()
+        self.weekly_summary.start()
+        self.cleanup_old_items.start()
+
+    async def cog_unload(self) -> None:
+        self.daily_fetch.cancel()
+        self.weekly_summary.cancel()
+        self.cleanup_old_items.cancel()
+        if self.session:
+            await self.session.close()
+
+    # ── Background tasks ─────────────────────────────────────────────
+
+    @tasks.loop(hours=24)
+    async def daily_fetch(self) -> None:
+        """Fetch today's RSS feed and store items for all configured guilds."""
+        await self.bot.wait_until_ready()
+
+        items = await fetch_rss_feed(self.session)
+        if not items:
+            log.info("RSS daily fetch: no items returned")
+            return
+
+        guilds = await self.bot.db.get_rss_guilds()
+        for guild_id, _ in guilds:
+            count = await self.bot.db.store_rss_items(guild_id, items)
+            log.info("RSS: stored %d new items for guild %d", count, guild_id)
+
+    @daily_fetch.before_loop
+    async def before_daily_fetch(self) -> None:
+        await self.bot.wait_until_ready()
+
+    @tasks.loop(hours=168)  # 7 days
+    async def weekly_summary(self) -> None:
+        """Generate and post a weekly summary to each configured guild."""
+        await self.bot.wait_until_ready()
+
+        guilds = await self.bot.db.get_rss_guilds()
+        for guild_id, channel_id in guilds:
+            await self._post_summary(guild_id, channel_id)
+
+    @weekly_summary.before_loop
+    async def before_weekly_summary(self) -> None:
+        await self.bot.wait_until_ready()
+
+    @tasks.loop(hours=168)  # weekly cleanup
+    async def cleanup_old_items(self) -> None:
+        """Delete RSS items older than 30 days."""
+        await self.bot.wait_until_ready()
+        deleted = await self.bot.db.delete_old_rss_items(30)
+        if deleted:
+            log.info("RSS cleanup: deleted %d old items", deleted)
+
+    @cleanup_old_items.before_loop
+    async def before_cleanup(self) -> None:
+        await self.bot.wait_until_ready()
+
+    # ── Helper ───────────────────────────────────────────────────────
+
+    async def _post_summary(self, guild_id: int, channel_id: int) -> None:
+        """Build and send the weekly summary embed to the configured channel."""
+        guild = self.bot.get_guild(guild_id)
+        if guild is None:
+            log.warning("RSS: guild %d not found, skipping summary", guild_id)
+            return
+
+        channel = guild.get_channel(channel_id)
+        if channel is None:
+            log.warning(
+                "RSS: channel %d not found in guild %d, skipping",
+                channel_id,
+                guild_id,
+            )
+            return
+
+        items = await self.bot.db.get_weekly_rss_items(guild_id)
+        if not items:
+            log.info("RSS: no items this week for guild %d", guild_id)
+            return
+
+        settings = await self.bot.db.get_guild_settings(guild_id)
+        model = settings["ai_model"] if settings else None
+
+        summary = await ai_weekly_summary(self.session, items, model)
+        if summary is None:
+            # Fallback: post a plain list if AI is unavailable
+            lines = [f"- [{it['title']}]({it['link']})" for it in items[:15]]
+            summary = "\n".join(lines)
+
+        embed = discord.Embed(
+            title="Weekly News Summary",
+            description=summary,
+            color=discord.Color.blue(),
+        )
+        embed.set_footer(text=f"Based on {len(items)} articles from this week")
+
+        try:
+            await channel.send(embed=embed)
+            log.info("RSS: posted weekly summary to guild %d", guild_id)
+        except discord.Forbidden:
+            log.warning(
+                "RSS: missing permissions to post in channel %d (guild %d)",
+                channel_id,
+                guild_id,
+            )
+
+    # ── Slash commands ───────────────────────────────────────────────
+
+    @app_commands.command(
+        name="rss-channel",
+        description="Set or view the channel for weekly RSS summaries",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.describe(channel="The channel to post weekly summaries in (omit to view current)")
+    @has_command_permission("rss-channel")
+    async def rss_channel(
+        self,
+        interaction: discord.Interaction,
+        channel: discord.TextChannel | None = None,
+    ) -> None:
+        guild_id = interaction.guild_id
+        await self.bot.db.ensure_guild(guild_id)
+
+        if channel is None:
+            current = await self.bot.db.get_rss_channel(guild_id)
+            if current is None:
+                await interaction.response.send_message(
+                    "No RSS summary channel configured. "
+                    "Use `/rss-channel #channel` to set one.",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.response.send_message(
+                    f"Weekly RSS summaries are posted to <#{current}>.",
+                    ephemeral=True,
+                )
+            return
+
+        await self.bot.db.set_rss_channel(guild_id, channel.id)
+        await interaction.response.send_message(
+            f"Weekly RSS summaries will now be posted to {channel.mention}.",
+            ephemeral=True,
+        )
+
+    @app_commands.command(
+        name="weeklysummary",
+        description="Get this week's RSS news summary on demand",
+    )
+    @app_commands.checks.cooldown(1, 30.0)
+    @has_command_permission("weeklysummary")
+    async def weekly_summary_cmd(self, interaction: discord.Interaction) -> None:
+        guild_id = interaction.guild_id
+        await self.bot.db.ensure_guild(guild_id)
+
+        items = await self.bot.db.get_weekly_rss_items(guild_id)
+        if not items:
+            await interaction.response.send_message(
+                "No RSS articles collected this week yet. "
+                "Make sure an admin has configured `/rss-channel` and wait for the daily fetch.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer()
+
+        settings = await self.bot.db.get_guild_settings(guild_id)
+        model = settings["ai_model"] if settings else None
+
+        summary = await ai_weekly_summary(self.session, items, model)
+        if summary is None:
+            lines = [f"- [{it['title']}]({it['link']})" for it in items[:15]]
+            summary = "\n".join(lines)
+
+        embed = discord.Embed(
+            title="Weekly News Summary",
+            description=summary,
+            color=discord.Color.blue(),
+        )
+        embed.set_footer(text=f"Based on {len(items)} articles from this week")
+        await interaction.followup.send(embed=embed)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RSS(bot))

--- a/config.py
+++ b/config.py
@@ -27,6 +27,9 @@ DEFAULT_SPAM_MUTE_SECS = 60
 DEFAULT_SCAN_LIMIT = 1000
 DEFAULT_NUKE_DAYS = 60
 
+# RSS feed
+METACURATE_RSS_URL = "https://metacurate.io/briefs/daily/latest/rss"
+
 # Command default access levels
 DEFAULT_COMMAND_ACCESS = {
     "help": "public",
@@ -36,4 +39,6 @@ DEFAULT_COMMAND_ACCESS = {
     "topchatter": "public",
     "inactive": "admin_only",
     "nuke": "admin_only",
+    "weeklysummary": "public",
+    "rss-channel": "admin_only",
 }

--- a/migrations/002_rss_feed.sql
+++ b/migrations/002_rss_feed.sql
@@ -1,0 +1,21 @@
+-- RSS feed storage for weekly summaries
+
+CREATE TABLE IF NOT EXISTS rss_guild_config (
+    guild_id INTEGER PRIMARY KEY,
+    rss_channel_id INTEGER DEFAULT NULL,
+    FOREIGN KEY (guild_id) REFERENCES guild_settings(guild_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS rss_feed_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    guild_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    link TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    published_at TEXT NOT NULL DEFAULT '',
+    fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (guild_id) REFERENCES guild_settings(guild_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_rss_feed_items_guild_fetched
+    ON rss_feed_items (guild_id, fetched_at);

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,4 +1,5 @@
 import logging
+import xml.etree.ElementTree as ET
 
 import aiohttp
 
@@ -63,4 +64,104 @@ async def ai_roast(
             return None
     except Exception:
         log.exception("OpenRouter request failed")
+        return None
+
+
+async def fetch_rss_feed(session: aiohttp.ClientSession) -> list[dict]:
+    """Fetch and parse the Metacurate RSS feed. Returns a list of item dicts."""
+    try:
+        async with session.get(config.METACURATE_RSS_URL) as resp:
+            if resp.status != 200:
+                log.warning("RSS feed returned status %d", resp.status)
+                return []
+            text = await resp.text()
+    except Exception:
+        log.exception("RSS feed request failed")
+        return []
+
+    items = []
+    try:
+        root = ET.fromstring(text)
+        # Standard RSS 2.0 structure: <rss><channel><item>...</item></channel></rss>
+        channel = root.find("channel")
+        if channel is None:
+            log.warning("RSS feed has no <channel> element")
+            return []
+        for item_el in channel.findall("item"):
+            title = item_el.findtext("title", "")
+            link = item_el.findtext("link", "")
+            description = item_el.findtext("description", "")
+            pub_date = item_el.findtext("pubDate", "")
+            if link:
+                items.append({
+                    "title": title,
+                    "link": link,
+                    "description": description,
+                    "published_at": pub_date,
+                })
+    except ET.ParseError:
+        log.exception("Failed to parse RSS XML")
+        return []
+
+    return items
+
+
+async def ai_weekly_summary(
+    session: aiohttp.ClientSession,
+    items: list[dict],
+    model: str | None = None,
+) -> str | None:
+    """Generate an AI summary of the week's RSS feed items via OpenRouter."""
+    if not config.OPENROUTER_API_KEY:
+        return None
+    if not items:
+        return None
+
+    model = model or config.DEFAULT_AI_MODEL
+
+    # Build a digest of the items for the AI
+    digest_lines = []
+    for item in items:
+        title = item.get("title", "Untitled")
+        desc = item.get("description", "")
+        link = item.get("link", "")
+        digest_lines.append(f"- **{title}**: {desc} ({link})")
+
+    digest = "\n".join(digest_lines)
+
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful tech news curator. You will receive a list of "
+                    "articles from the past week's daily tech briefs. Create a concise, "
+                    "engaging weekly summary that highlights the most important themes "
+                    "and stories. Group related items together. Keep the summary under "
+                    "1500 characters so it fits well in a Discord message. Use markdown "
+                    "formatting suitable for Discord."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Here are this week's articles:\n\n{digest}",
+            },
+        ],
+    }
+    headers = {
+        "Authorization": f"Bearer {config.OPENROUTER_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    try:
+        async with session.post(
+            config.OPENROUTER_API_URL, json=payload, headers=headers
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                return data["choices"][0]["message"]["content"]
+            log.warning("OpenRouter returned status %d for weekly summary", resp.status)
+            return None
+    except Exception:
+        log.exception("OpenRouter weekly summary request failed")
         return None


### PR DESCRIPTION
Implements the feature from todo-list-claude.txt:
- Daily background task fetches Metacurate.io RSS feed and stores articles
- Weekly background task generates an AI summary via OpenRouter and posts it
- /rss-channel command (admin) to configure which channel receives summaries
- /weeklysummary command (public) to get an on-demand summary
- Database migration for rss_guild_config and rss_feed_items tables
- Automatic cleanup of articles older than 30 days

https://claude.ai/code/session_019duRiTRsPwP5rHe2rW2v9h