### PR TITLE
Add /rss-fetch command and update README with RSS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A modular Discord bot with per-server configurable permissions, slash commands, 
 ## Features
 
 - **Slash commands** — `/ping`, `/help`, `/meme`, `/roastme`, `/topchatter`, `/inactive`, `/nuke`
+- **Weekly RSS summaries** — daily fetch from [Metacurate.io](https://metacurate.io/briefs/daily/latest/rss), AI-powered weekly digest via OpenRouter
 - **Per-server permissions** — 3-tier system (public / admin-only / restricted by role)
 - **Interactive setup wizard** — `/setup` walks admins through configuration
 - **Anti-spam** — automatic muting when message rate exceeds threshold
@@ -40,7 +41,7 @@ python bot.py
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DISCORD_TOKEN` | Yes | Your Discord bot token |
-| `OPENROUTER_API_KEY` | No | Enables `/roastme` AI features |
+| `OPENROUTER_API_KEY` | No | Enables `/roastme` and weekly RSS summaries |
 | `HUMOR_API_KEY` | No | Enables `/meme` command |
 | `DATABASE_PATH` | No | SQLite path (default: `sattbot.db`) |
 | `LOG_LEVEL` | No | Logging level (default: `INFO`) |
@@ -51,6 +52,7 @@ python bot.py
 - `/config` — View or change individual settings
 - `/permissions` — Grant/revoke role access to commands
 - `/permissions-view` — See current permission settings
+- `/rss-channel #channel` — Set which channel receives the weekly RSS summary
 
 ## Permission System
 
@@ -64,8 +66,8 @@ Three layers of access control:
 
 | Command | Default |
 |---------|---------|
-| `/help`, `/ping`, `/meme`, `/roastme`, `/topchatter` | public |
-| `/inactive`, `/nuke` | admin_only |
+| `/help`, `/ping`, `/meme`, `/roastme`, `/topchatter`, `/weeklysummary` | public |
+| `/inactive`, `/nuke`, `/rss-channel`, `/rss-fetch` | admin_only |
 
 ### Example
 
@@ -73,6 +75,34 @@ Three layers of access control:
 /permissions command:inactive action:Grant role:@Mods
 → Now only @Mods and admins can use /inactive
 ```
+
+## Weekly RSS Summary
+
+SattBot can pull the daily tech brief from [Metacurate.io](https://metacurate.io/) and generate a weekly AI-powered summary posted to a channel of your choice.
+
+### How it works
+
+1. **Daily fetch** — A background task runs every 24 hours and downloads articles from the [Metacurate RSS feed](https://metacurate.io/briefs/daily/latest/rss). Articles are stored in the database per guild.
+2. **Weekly summary** — Every 7 days the bot sends the stored articles to OpenRouter, which generates a concise digest and posts it as an embed in the configured channel.
+3. **Cleanup** — Articles older than 30 days are automatically deleted.
+
+### RSS Commands
+
+| Command | Access | Description |
+|---------|--------|-------------|
+| `/rss-channel [#channel]` | Admin | Set or view the channel that receives weekly summaries |
+| `/rss-fetch` | Admin | Manually trigger an RSS fetch (useful for testing) |
+| `/weeklysummary` | Public | Get this week's summary on demand |
+
+### Setup
+
+```
+/rss-channel #news
+```
+
+That's it. The bot will start collecting articles and post its first summary after 7 days (or use `/weeklysummary` any time to get one immediately).
+
+> **Note:** The `OPENROUTER_API_KEY` environment variable is required for AI summaries. Without it the bot falls back to posting a plain list of article links.
 
 ## Project Structure
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -62,6 +62,7 @@ class General(commands.Cog):
             "config": "Change server settings (Admin)",
             "weeklysummary": "Get this week's RSS news summary",
             "rss-channel": "Set the channel for weekly summaries (Admin)",
+            "rss-fetch": "Manually fetch the RSS feed now (Admin)",
         }
 
         # Always show admin commands to admins

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -165,6 +165,42 @@ class RSS(commands.Cog):
         )
 
     @app_commands.command(
+        name="rss-fetch",
+        description="Manually fetch the RSS feed now (for testing)",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @has_command_permission("rss-fetch")
+    async def rss_fetch(self, interaction: discord.Interaction) -> None:
+        guild_id = interaction.guild_id
+        await self.bot.db.ensure_guild(guild_id)
+
+        rss_channel = await self.bot.db.get_rss_channel(guild_id)
+        if rss_channel is None:
+            await interaction.response.send_message(
+                "No RSS channel configured yet. Use `/rss-channel #channel` first.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        items = await fetch_rss_feed(self.session)
+        if not items:
+            await interaction.followup.send(
+                "RSS fetch returned no items. The feed may be temporarily unavailable.",
+                ephemeral=True,
+            )
+            return
+
+        count = await self.bot.db.store_rss_items(guild_id, items)
+
+        await interaction.followup.send(
+            f"Fetched **{len(items)}** article(s) from Metacurate.io — "
+            f"**{count}** new item(s) stored ({len(items) - count} duplicates skipped).",
+            ephemeral=True,
+        )
+
+    @app_commands.command(
         name="weeklysummary",
         description="Get this week's RSS news summary on demand",
     )

--- a/config.py
+++ b/config.py
@@ -41,4 +41,5 @@ DEFAULT_COMMAND_ACCESS = {
     "nuke": "admin_only",
     "weeklysummary": "public",
     "rss-channel": "admin_only",
+    "rss-fetch": "admin_only",
 }


### PR DESCRIPTION
- Add /rss-fetch admin command to manually trigger an RSS feed pull from Metacurate.io for testing that the fetch pipeline works
- Update README.md with full RSS feature documentation, setup instructions, and command reference table
